### PR TITLE
Ivan timeout error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,5 +17,6 @@ Sample Configuration:
     'project' => 'your-project-id',
     'queue'   => 'your-queue-name',
     'encrypt' => true,
+    'timeout' => 120,
 ],
 ```

--- a/src/Connectors/IronConnector.php
+++ b/src/Connectors/IronConnector.php
@@ -6,6 +6,7 @@ use IronMQ\IronMQ;
 use Illuminate\Http\Request;
 use Collective\IronQueue\IronQueue;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
+use Illuminate\Queue\Connectors\ConnectorInterface;
 
 class IronConnector implements ConnectorInterface
 {

--- a/src/Connectors/IronConnector.php
+++ b/src/Connectors/IronConnector.php
@@ -6,7 +6,6 @@ use IronMQ\IronMQ;
 use Illuminate\Http\Request;
 use Collective\IronQueue\IronQueue;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
-use Illuminate\Queue\Connectors\ConnectorInterface;
 
 class IronConnector implements ConnectorInterface
 {


### PR DESCRIPTION
I added `timeout` to the documentation readme file because without `timeout` in configuration we get `Undefined index: timeout` error.

Reason for this error is in `IronConnector.php` line 63 we have 

```return new IronQueue($iron, $this->request, $config['queue'], $config['encrypt'], $config['timeout']);```

This PR can help people to just copy the config from documentation and avoid the error.



